### PR TITLE
Allow variable number of microsecond digits

### DIFF
--- a/lib/heroku-log-parser.rb
+++ b/lib/heroku-log-parser.rb
@@ -22,7 +22,7 @@ class HerokuLogParser
     # frame <prority>version time hostname <appname-missing> procid msgid [no structured data = '-'] msg
     # 120 <40>1 2013-07-26T18:39:37.489572+00:00 host app web.11 - State changed from starting to up...
     def line_regex
-      @line_regex ||= /\<(\d+)\>(1) (\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d\d\d\d\d\d)?\+00:00) ([a-z0-9\-\_\.]+) ([a-z0-9\.-]+) ([a-z0-9\-\_\.]+) (\-) (.*)$/
+      @line_regex ||= /\<(\d+)\>(1) (\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?\+00:00) ([a-z0-9\-\_\.]+) ([a-z0-9\.-]+) ([a-z0-9\-\_\.]+) (\-) (.*)$/
     end
 
     # Heroku's http log drains (https://devcenter.heroku.com/articles/labs-https-drains)

--- a/test/heroku_log_parser_test.rb
+++ b/test/heroku_log_parser_test.rb
@@ -72,4 +72,9 @@ describe HerokuLogParser do
     assert_equal expected_second, actual[1]
   end
 
+  it "allows variable microsecond precision" do
+    msg = "283 <158>1 2022-01-26T20:25:08.61556+00:00 host heroku router - at=info method=GET path=\"/tags\" host=mine.herokuapp.com request_id=b4dffe63-d7c8-4b65-9938-55b54d7b7efa fwd=\"1.1.1.1,1.1.1.2\" dyno=web.1 connect=0ms service=51ms status=200 bytes=27662 protocol=https\n"
+    actual = HerokuLogParser.parse(msg)
+    refute_empty actual
+  end
 end


### PR DESCRIPTION
Log lines were failing to parse b/c they had only 5 microsecond digits